### PR TITLE
English review of #2 Hands On

### DIFF
--- a/2-Try-Trainer-class_en.ipynb
+++ b/2-Try-Trainer-class_en.ipynb
@@ -1,4 +1,5 @@
-": [
+{
+ "cells": [
   {
    "cell_type": "markdown",
    "metadata": {},

--- a/2-Try-Trainer-class_en.ipynb
+++ b/2-Try-Trainer-class_en.ipynb
@@ -152,7 +152,7 @@
     "# Note: L.Classifier is actually a chain that wraps 'model' to add a loss\n",
     "# function.\n",
     "# Since we do not specify a loss funciton here, the default \n",
-    "#'softmax_cross_entropy' is used.\n",
+    "# 'softmax_cross_entropy' is used.\n",
     "# The output of this modified 'model' will now be a loss value instead\n",
     "# of a class label prediction.\n",
     "model = L.Classifier(model)\n",
@@ -220,7 +220,7 @@
    "source": [
     "## 6. Add extensions to trainer\n",
     "\n",
-    "There are several optional trainer extensions that provide the following capabilites: \n",
+    "There are several optional trainer `extensions` that provide the following capabilites: \n",
     "\n",
     "- Save log files automatically (`LogReport`)\n",
     "- Display the training information to the terminal periodically (`PrintReport`)\n",

--- a/2-Try-Trainer-class_en.ipynb
+++ b/2-Try-Trainer-class_en.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "Chainer contains several extensions that can be used with `Trainer` to visualize your results, evaluate your model, store and manage log files more easily.\n",
     "\n",
-    "This example will show how to use the Trainer feature to train a fully-connected feed-forward neural network on the MNIST dataset."
+    "This example will show how to use the `Trainer` feature to train a fully-connected feed-forward neural network on the MNIST dataset."
    ]
   },
   {
@@ -107,7 +107,7 @@
     "gpu_id = 0  # Set to -1 if you don't have a GPU\n",
     "\n",
     "model = MLP()\n",
-    "if gpu_id >=0:\n",
+    "if gpu_id >= 0:\n",
     "        model.to_gpu(gpu_id)"
    ]
   },
@@ -477,15 +477,6 @@
    "source": [
     "It successfully executed !!"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/2-Try-Trainer-class_en.ipynb
+++ b/2-Try-Trainer-class_en.ipynb
@@ -108,7 +108,7 @@
     "\n",
     "model = MLP()\n",
     "if gpu_id >= 0:\n",
-    "        model.to_gpu(gpu_id)"
+    "    model.to_gpu(gpu_id)"
    ]
   },
   {
@@ -159,7 +159,7 @@
     "\n",
     "# Send the model to the GPU.\n",
     "if gpu_id >= 0:\n",
-    "        model.to_gpu(gpu_id)\n",
+    "    model.to_gpu(gpu_id)\n",
     "\n",
     "# selection of your optimizing method\n",
     "optimizer = optimizers.SGD()\n",
@@ -455,7 +455,7 @@
     "serializers.load_npz('mnist_result/model_epoch-10', model)\n",
     "\n",
     "if gpu_id >=0:\n",
-    "        model.to_gpu(gpu_id)\n",
+    "    model.to_gpu(gpu_id)\n",
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "\n",

--- a/2-Try-Trainer-class_en.ipynb
+++ b/2-Try-Trainer-class_en.ipynb
@@ -282,7 +282,7 @@
     "\n",
     "### `dump_graph`\n",
     "\n",
-    "This method saves the computaional graph of the model. The graph is saved in `Graphviz` dot format. The output location (directory) to save the graph is set by the `out` argument of `Trainer`. \n",
+    "This method saves the computational graph of the model. The graph is saved in `Graphviz` dot format. The output location (directory) to save the graph is set by the `out` argument of `Trainer`. \n",
     "\n",
     "---\n",
     "\n",

--- a/2-Try-Trainer-class_en.ipynb
+++ b/2-Try-Trainer-class_en.ipynb
@@ -159,7 +159,7 @@
     "\n",
     "# Send the model to the GPU.\n",
     "if gpu_id >= 0:\n",
-    "        model.to_gpu(gpu_id)\n"
+    "        model.to_gpu(gpu_id)\n",
     "\n",
     "# selection of your optimizing method\n",
     "optimizer = optimizers.SGD()\n",
@@ -455,7 +455,7 @@
     "serializers.load_npz('mnist_result/model_epoch-10', model)\n",
     "\n",
     "if gpu_id >=0:\n",
-    "        model.to_gpu(gpu_id)"
+    "        model.to_gpu(gpu_id)\n",
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "\n",

--- a/2-Try-Trainer-class_en.ipynb
+++ b/2-Try-Trainer-class_en.ipynb
@@ -1,12 +1,11 @@
-{
- "cells": [
+": [
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Using the Trainer feature\n",
     "\n",
-    "Chain has a feature called `Trainer` that can often be used to simplify the process of training and evaluating a model. This feature supports training a model in a way such that the user is not required to explicitly write the code for the training loop. For many types of models, including our MNIST model, `Trainer` allows us to write our training and evaluation code much more concisely.\n",
+    "Chainer has a feature called `Trainer` that can often be used to simplify the process of training and evaluating a model. This feature supports training a model in a way such that the user is not required to explicitly write the code for the training loop. For many types of models, including our MNIST model, `Trainer` allows us to write our training and evaluation code much more concisely.\n",
     "\n",
     "Chainer contains several extensions that can be used with `Trainer` to visualize your results, evaluate your model, store and manage log files more easily.\n",
     "\n",
@@ -104,19 +103,20 @@
     "        h2 = F.relu(self.l2(h1))\n",
     "        return self.l3(h2)\n",
     "\n",
-    "gpu_id = 0\n",
+    "gpu_id = 0  # Set to -1 if you don't have a GPU\n",
     "\n",
     "model = MLP()\n",
-    "model.to_gpu(gpu_id)"
+    "if gpu_id >=0:\n",
+    "        model.to_gpu(gpu_id)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4. Prepare the Updator\n",
+    "## 4. Prepare the Updater\n",
     "\n",
-    "As mentioned above, the trainer object (instance of `Trainer`) actually implements the training loop for us. However, before we can use it, we must first prepare another object that will actually perform one iteration of training operations and pass it to the trainer. This other object will be an subclass of `Updator` such as `StandardUpdater` or a custom subclass. It will therefore need to hold all of the components that are needed in order to perform one iteration of training, such as a dataset iterator, and and optimizer that also holds the model.\n",
+    "As mentioned above, the trainer object (instance of `Trainer`) actually implements the training loop for us. However, before we can use it, we must first prepare another object that will actually perform one iteration of training operations and pass it to the trainer. This other object will be an subclass of `Updater` such as `StandardUpdater` or a custom subclass. It will therefore need to hold all of the components that are needed in order to perform one iteration of training, such as a dataset iterator, and optimizer that also holds the model.\n",
     "\n",
     "- Updater\n",
     "    - Iterator\n",
@@ -132,7 +132,7 @@
     "\n",
     "Once the updater has been set up, we can pass it to the trainer and start the training process. The trainer will then automatically create the training loop and call the updater once per iteration.\n",
     "\n",
-    "Now let's create the updator object.`"
+    "Now let's create the updater object."
    ]
   },
   {
@@ -147,8 +147,6 @@
     "from chainer import training\n",
     "\n",
     "max_epoch = 10\n",
-    "# Note: If you don't have a GPU, set this to -1 to run on CPU only\n",
-    "gpu_id = 0\n",
     "\n",
     "# Note: L.Classifier is actually a chain that wraps 'model' to add a loss\n",
     "# function.\n",
@@ -159,14 +157,15 @@
     "model = L.Classifier(model)\n",
     "\n",
     "# Send the model to the GPU.\n",
-    "model.to_gpu(gpu_id)\n",
+    "if gpu_id >= 0:\n",
+    "        model.to_gpu(gpu_id)\n"
     "\n",
     "# selection of your optimizing method\n",
     "optimizer = optimizers.SGD()\n",
     "# Give the optimizer a reference to the model\n",
     "optimizer.setup(model)\n",
     "\n",
-    "# Get an Updator that uses the Iterator and Optimizer\n",
+    "# Get an Updater that uses the Iterator and Optimizer\n",
     "updater = training.StandardUpdater(train_iter, optimizer, device=gpu_id)"
    ]
   },
@@ -180,7 +179,7 @@
     "\n",
     "Specifically, when `__call__` is called on our model (which is now a `L.Classifier` object), the image batch is supplied to its `predictor` attribute, which contains our `MLP` model. The ourput of the `MLP` (which consists of class label predictions) is supplied to the loss function along with the target class labels to compute the loss value which is then returned as a `Variable` object.\n",
     "\n",
-    "Note that we use `StandardUpdator`, which is the simplest type of `Updator` in Chainer. There are also other types of updaters available, such as `ParallelUpdator` (which is intended for multiple GPUs) and you can also write a custom updater if you wish."
+    "Note that we use `StandardUpdater`, which is the simplest type of `Updater` in Chainer. There are also other types of updaters available, such as `ParallelUpdater` (which is intended for multiple GPUs) and you can also write a custom updater if you wish."
    ]
   },
   {
@@ -189,7 +188,7 @@
    "source": [
     "## 5. Setup Trainer\n",
     "\n",
-    "Now that we have set up an updater, we can pass it to a `Trainer` object. You can optionally pass a `stop_trigger` to the second trainer argument as a tuple, `(length, unit)` to tell the trainer stop automatically according to your indicated timing. The `length` is given as an arbitrary integer and `unit` is given as a string which currently must be either 'epoch' or 'iteration'. Without setting `stop_trigger`, the training will not stop automatically."
+    "Now that we have set up an updater, we can pass it to a `Trainer` object. You can optionally pass a `stop_trigger` to the second trainer argument as a tuple, `(length, unit)` to tell the trainer stop automatically according to your indicated timing. The `length` is given as an arbitrary integer and `unit` is given as a string which currently must be either `epoch` or `iteration`. Without setting `stop_trigger`, the training will not stop automatically."
    ]
   },
   {
@@ -211,7 +210,7 @@
    "source": [
     "The `out` argument in the trainer will set up an output directory to save the logfiles, the image files of graphs to show the time progress of loss, accuracy, etc. \n",
     "\n",
-    "Next, we will explain how to display/save those outputs by using 'Extension'. "
+    "Next, we will explain how to display/save those outputs by using `extensions`. "
    ]
   },
   {
@@ -222,14 +221,14 @@
     "\n",
     "There are several optional trainer extensions that provide the following capabilites: \n",
     "\n",
-    "- Save log files automatically ('LogReport')\n",
-    "- Display the training information to the terminal periodically ('PrintReport')\n",
-    "- Visualize the loss progress by plottig a graph periodically and save its image ('PlotReport')\n",
-    "- Automatically serialize the model or the state of Optimizer periodically ('snapshot'/'snapshot_object')\n",
-    "- Display Progress Bar to show the progress of training ('ProgressBar')\n",
-    "- Save the model architechture as a dot format readable by Graphviz ('dump_graph')\n",
+    "- Save log files automatically (`LogReport`)\n",
+    "- Display the training information to the terminal periodically (`PrintReport`)\n",
+    "- Visualize the loss progress by plottig a graph periodically and save its image (`PlotReport`)\n",
+    "- Automatically serialize the model or the state of Optimizer periodically (`snapshot`/`snapshot_object`)\n",
+    "- Display Progress Bar to show the progress of training (`ProgressBar`)\n",
+    "- Save the model architecture as a dot format readable by `Graphviz` (`dump_graph`)\n",
     "\n",
-    "Now you can utilize the wide variety of tools shown above right away! To do so, simply pass the desired `Extension` object to the `Trainer` object by using the `extend()` method of `Trainer`."
+    "Now you can utilize the wide variety of tools shown above right away! To do so, simply pass the desired `extensions` object to the `Trainer` object by using the `extend()` method of `Trainer`."
    ]
   },
   {
@@ -243,12 +242,12 @@
     "from chainer.training import extensions\n",
     "\n",
     "trainer.extend(extensions.LogReport())\n",
-    "trainer.extend(extensions.snapshot(filename='snapshot_epoch-{.updater.epoch}'))\n",
-    "trainer.extend(extensions.snapshot_object(model.predictor, filename='model_epoch-{.updater.epoch}'))\n",
-    "trainer.extend(extensions.Evaluator(test_iter, model, device=gpu_id))\n",
     "trainer.extend(extensions.PrintReport(['epoch', 'main/loss', 'main/accuracy', 'validation/main/loss', 'validation/main/accuracy', 'elapsed_time']))\n",
     "trainer.extend(extensions.PlotReport(['main/loss', 'validation/main/loss'], x_key='epoch', file_name='loss.png'))\n",
     "trainer.extend(extensions.PlotReport(['main/accuracy', 'validation/main/accuracy'], x_key='epoch', file_name='accuracy.png'))\n",
+    "trainer.extend(extensions.snapshot(filename='snapshot_epoch-{.updater.epoch}'))\n",
+    "trainer.extend(extensions.snapshot_object(model.predictor, filename='model_epoch-{.updater.epoch}'))\n",
+    "trainer.extend(extensions.Evaluator(test_iter, model, device=gpu_id))\n",
     "trainer.extend(extensions.dump_graph('main/loss'))"
    ]
   },
@@ -258,23 +257,7 @@
    "source": [
     "### `LogReport`\n",
     "\n",
-    "Collect 'loss' and 'accuracy' automarically every 'epoch' or 'iteration' and store the information under the 'log' file in the directory assigned by the 'out' argument of 'Trainer'\n",
-    "\n",
-    "### `snapshot`\n",
-    "\n",
-    "The 'snapshot' method saves the 'Trainer' object at the designated timing (defaut: every epoch) in the directory assigned by 'out' argument in 'Trainer'. The 'Trainer' object, as mentioned before, has an 'Updator' which contains an 'Optimizer' and a model inside. Therefore, as long as you have the snapshot file, you can use it to come back to the training or make inferences using the previously trained model later. \n",
-    "\n",
-    "### `snapshot_object`\n",
-    "\n",
-    "When you save the whole 'Trainer' object, in some cases it is very tedious to retrieve only the inside of the model. By using 'snapshot_object', you can save the particular object (in this case, the model wrapped by `Classifier`) in addition to saving the`Traine` object. `Classifier` is a `Chain` object that keeps the `Chain` object given by the first argument as a property called `predictor` and calculates the loss. `Classifier` doesn't have any parameters other than those inside its predictor model, and so we only save `model.predictor`. \n",
-    "\n",
-    "### `dump_graph`\n",
-    "\n",
-    "This method saves the computaional graph of the model. The graph is saved in Graphviz dot format. The output location (directory) to save the graph is set by the 'out' argument of `Trainer`. \n",
-    "\n",
-    "### `Evaluator`\n",
-    "\n",
-    "The 'Iterator' that uses the evaluation dataset (such as a validation or test dataset) and the model object are passed to 'Evaluator'. The 'Evaluator' evaluates the model using the given dataset at the specified timing interval. \n",
+    "Collect `loss` and `accuracy` automatically every `epoch` or `iteration` and store the information under the `log` file in the directory assigned by the `out` argument of `Trainer`.\n",
     "\n",
     "### `PrintReport`\n",
     "\n",
@@ -284,9 +267,25 @@
     "\n",
     "`PlotReport` plots the values specified by its arguments, draws the graph and saves the image in the directory set by 'file name'.\n",
     "\n",
+    "### `snapshot`\n",
+    "\n",
+    "The `snapshot` method saves the `Trainer` object at the designated timing (defaut: every epoch) in the directory assigned by `out` argument in `Trainer`. The `Trainer` object, as mentioned before, has an `Updater` which contains an `Optimizer` and a model inside. Therefore, as long as you have the snapshot file, you can use it to come back to the training or make inferences using the previously trained model later. \n",
+    "\n",
+    "### `snapshot_object`\n",
+    "\n",
+    "When you save the whole `Trainer` object, in some cases it is very tedious to retrieve only the inside of the model. By using `snapshot_object`, you can save the particular object (in this case, the model wrapped by `Classifier`) in addition to saving the `Trainer` object. `Classifier` is a `Chain` object that keeps the `Chain` object given by the first argument as a property called `predictor` and calculates the loss. `Classifier` doesn't have any parameters other than those inside its predictor model, and so we only save `model.predictor`. \n",
+    "\n",
+    "### `Evaluator`\n",
+    "\n",
+    "The `Iterator` that uses the evaluation dataset (such as a validation or test dataset) and the model object are passed to `Evaluator`. The `Evaluator` evaluates the model using the given dataset at the specified timing interval. \n",
+    "\n",
+    "### `dump_graph`\n",
+    "\n",
+    "This method saves the computaional graph of the model. The graph is saved in `Graphviz` dot format. The output location (directory) to save the graph is set by the `out` argument of `Trainer`. \n",
+    "\n",
     "---\n",
     "\n",
-    "The `Extension` class has a lot of options other than those mentioned here. For instance, by using the 'trigger' option, you can set individual timings to activate the 'Extension' more flexibly. Please take a look at the official document in more detail：[Trainer extensions](http://docs.chainer.org/en/latest/reference/extensions.html)"
+    "The `extensions` class has a lot of options other than those mentioned here. For instance, by using the `trigger` option, you can set individual timings to activate the `extensions` more flexibly. Please take a look at the official document in more detail：[Trainer extensions](http://docs.chainer.org/en/latest/reference/extensions.html)"
    ]
   },
   {
@@ -295,7 +294,7 @@
    "source": [
     "## 7. Start Training\n",
     "\n",
-    "To start training, just call 'run' method from 'Trainer' object."
+    "To start training, just call `run` method from `Trainer` object."
    ]
   },
   {
@@ -331,7 +330,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's see the graph of loss saved in the 'mnist_result' directory. "
+    "Let's see the graph of loss saved in the `mnist_result` directory. "
    ]
   },
   {
@@ -392,7 +391,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Furthermore, let's visualize the computaional graph output by 'dump_graph' of 'Extension' using 'Graphviz'. "
+    "Furthermore, let's visualize the computational graph output by `dump_graph` of `extensions` using `Graphviz`. "
    ]
   },
   {
@@ -411,7 +410,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "From the top to the bottom, you can track the data flow of the computations, how data and paremeters are passed to what type of 'Function' and the calculated loss is output. "
+    "From the top to the bottom, you can track the data flow of the computations, how data and parameters are passed to what type of `Function` and the calculated loss is output. "
    ]
   },
   {
@@ -450,13 +449,12 @@
    "source": [
     "import numpy as np\n",
     "from chainer import serializers\n",
-    "from chainer.cuda import to_gpu\n",
-    "from chainer.cuda import to_cpu\n",
     "\n",
     "model = MLP()\n",
     "serializers.load_npz('mnist_result/model_epoch-10', model)\n",
-    "model.to_gpu(gpu_id)\n",
     "\n",
+    "if gpu_id >=0:\n",
+    "        model.to_gpu(gpu_id)"
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
@@ -465,9 +463,9 @@
     "plt.show()\n",
     "print('label:', t)\n",
     "\n",
-    "x = to_gpu(x[None, ...])\n",
+    "x = x[None, ...]\n",
     "y = model(x)\n",
-    "y = to_cpu(y.data)\n",
+    "y = y.data\n",
     "\n",
     "print('predicted_label:', y.argmax(axis=1)[0])"
    ]


### PR DESCRIPTION
Correct English spellings
Fix for non-NVIDIA GPU computers to use gpu_id = -1
Remove unnecessary to_gpu and to_cpu code
Reorder lists of extensions explanations to match code
Make all code words use code formatting with `code` style instead of 'code'.
Minor text fixes

** Please test on NVIDIA GPU machine to ensure new code works!

If this is ok, I'll make the similar ordering and code changes to the JPY version as well.